### PR TITLE
Do not require `std` when building docs.

### DIFF
--- a/lzss/src/dynamic/mod.rs
+++ b/lzss/src/dynamic/mod.rs
@@ -89,7 +89,7 @@ impl LzssDyn {
   /// `alloc/std` Compress the input data into the output.
   ///
   /// The buffer, with `2 * (1 << EI)` bytes, is allocated on the heap.
-  #[cfg(any(doc, test, feature = "alloc"))]
+  #[cfg(any(test, feature = "alloc"))]
   pub fn compress<R: Read, W: Write>(
     &self,
     mut reader: R,
@@ -118,7 +118,7 @@ impl LzssDyn {
   /// `alloc/std` Decompress the input data into the output.
   ///
   /// The buffer, with `1 << EI` bytes, is allocated on the heap.
-  #[cfg(any(doc, test, feature = "alloc"))]
+  #[cfg(any(test, feature = "alloc"))]
   pub fn decompress<R: Read, W: Write>(
     &self,
     mut reader: R,
@@ -170,7 +170,7 @@ impl core::fmt::Display for LzssDynError {
 }
 
 /// `std` Implementation of [Error](std::error::Error) for [LzssDynError]
-#[cfg(any(doc, test, feature = "std"))]
+#[cfg(any(test, feature = "std"))]
 impl std::error::Error for LzssDynError {}
 
 #[cfg(test)]

--- a/lzss/src/error.rs
+++ b/lzss/src/error.rs
@@ -19,7 +19,7 @@ impl<R: Display, W: Display> core::fmt::Display for LzssError<R, W> {
 }
 
 /// `std` Implementation of [Error](std::error::Error) for [LzssError]
-#[cfg(any(doc, test, feature = "std"))]
+#[cfg(any(test, feature = "std"))]
 impl<R, W> std::error::Error for LzssError<R, W>
 where
   R: std::error::Error + 'static,

--- a/lzss/src/lib.rs
+++ b/lzss/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(any(doc, test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(feature = "const_panic", feature(const_panic))]
 // Allow many single char names, this is done to copy the original code as close as possible.
 #![allow(clippy::many_single_char_names)]
@@ -94,22 +94,22 @@ mod bits;
 mod dynamic;
 mod error;
 mod generic;
-#[cfg(any(doc, test, feature = "std"))]
+#[cfg(any(test, feature = "std"))]
 mod io_simple;
 mod read_write;
 mod slice;
-#[cfg(any(doc, test, feature = "alloc"))]
+#[cfg(any(test, feature = "alloc"))]
 mod vec;
 mod void;
 
 pub use crate::dynamic::{LzssDyn, LzssDynError};
 pub use crate::error::LzssError;
 pub use crate::generic::Lzss;
-#[cfg(any(doc, test, feature = "std"))]
+#[cfg(any(test, feature = "std"))]
 pub use crate::io_simple::{IOSimpleReader, IOSimpleWriter};
 pub use crate::read_write::{Read, Write};
 pub use crate::slice::{SliceReader, SliceWriteError, SliceWriter, SliceWriterExact};
-#[cfg(any(doc, test, feature = "alloc"))]
+#[cfg(any(test, feature = "alloc"))]
 pub use crate::vec::VecWriter;
 pub use crate::void::{
   ResultLzssErrorVoidExt, ResultLzssErrorVoidReadExt, ResultLzssErrorVoidWriteExt,

--- a/lzss/src/slice.rs
+++ b/lzss/src/slice.rs
@@ -59,7 +59,7 @@ impl core::fmt::Display for SliceWriteError {
   }
 }
 
-#[cfg(any(doc, test, feature = "std"))]
+#[cfg(any(test, feature = "std"))]
 impl std::error::Error for SliceWriteError {}
 
 /// Write into a slice.


### PR DESCRIPTION
In the current version of `lzss` the documentation can not be build for targets that don't have `std`. Since this library is intended to work on targets without `std` the documentation should also build without `std`.

Therefore, this PR removes the dependency on `std` for documentation.
