### PR TITLE
Use safe Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "lzss",
     "lzss-cli",
+    "fuzzing",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,9 @@ members = [
     "lzss",
     "lzss-cli",
 ]
+
+[profile.release]
+debug = true
+
+[profile.bench]
+debug = true

--- a/fuzzing/.gitignore
+++ b/fuzzing/.gitignore
@@ -1,0 +1,2 @@
+hfuzz_target/
+hfuzz_workspace/

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lzss-fuzzing"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lzss = {path = "../lzss"}
+honggfuzz = "0.5"

--- a/fuzzing/README.mkdn
+++ b/fuzzing/README.mkdn
@@ -1,0 +1,11 @@
+# Fuzz testing
+
+To run the fuzz tests:
+
+```
+$ cargo install honggfuzz
+$ cargo hfuzz run dynamic_compress
+$ cargo hfuzz run dynamic_decompress
+$ cargo hfuzz run generic_compress
+$ cargo hfuzz run generic_decompress
+```

--- a/fuzzing/src/bin/dynamic_compress.rs
+++ b/fuzzing/src/bin/dynamic_compress.rs
@@ -1,0 +1,18 @@
+use honggfuzz::fuzz;
+use lzss::{SliceReader, VecWriter, ResultLzssErrorVoidExt, LzssDyn};
+
+const EI: usize = 10;
+const EJ: usize = 4;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            LzssDyn::new(EI, EJ, 0x20).unwrap()
+                .compress(
+                    SliceReader::new(data),
+                    VecWriter::with_capacity(data.len()),
+                )
+                .void_unwrap();
+        });
+    }
+}

--- a/fuzzing/src/bin/dynamic_decompress.rs
+++ b/fuzzing/src/bin/dynamic_decompress.rs
@@ -1,0 +1,18 @@
+use honggfuzz::fuzz;
+use lzss::{SliceReader, VecWriter, ResultLzssErrorVoidExt, LzssDyn};
+
+const EI: usize = 10;
+const EJ: usize = 4;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            LzssDyn::new(EI, EJ, 0x20).unwrap()
+                .decompress(
+                    SliceReader::new(data),
+                    VecWriter::with_capacity(data.len()),
+                )
+                .void_unwrap();
+        });
+    }
+}

--- a/fuzzing/src/bin/generic_compress.rs
+++ b/fuzzing/src/bin/generic_compress.rs
@@ -1,0 +1,17 @@
+use honggfuzz::fuzz;
+use lzss::{Lzss, SliceReader, VecWriter, ResultLzssErrorVoidExt};
+
+const EI: usize = 10;
+const EJ: usize = 4;
+type MyLzss = Lzss<EI, EJ, 0x20, {1 << EI}, {2 << EI}>;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            MyLzss::compress_heap(
+                SliceReader::new(data),
+                VecWriter::with_capacity(data.len()),
+            ).void_unwrap();
+        });
+    }
+}

--- a/fuzzing/src/bin/generic_decompress.rs
+++ b/fuzzing/src/bin/generic_decompress.rs
@@ -1,0 +1,17 @@
+use honggfuzz::fuzz;
+use lzss::{Lzss, SliceReader, VecWriter, ResultLzssErrorVoidExt};
+
+const EI: usize = 10;
+const EJ: usize = 4;
+type MyLzss = Lzss<EI, EJ, 0x20, {1 << EI}, {2 << EI}>;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let r = MyLzss::decompress_heap(
+                SliceReader::new(data),
+                VecWriter::with_capacity(data.len()),
+            ).void_unwrap();
+        });
+    }
+}

--- a/lzss/Cargo.toml
+++ b/lzss/Cargo.toml
@@ -17,3 +17,10 @@ default = ['std']
 const_panic = []
 alloc = []
 std = ['void/std', 'alloc']
+
+[dev-dependencies]
+criterion = "0.4"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/lzss/benches/benchmark.rs
+++ b/lzss/benches/benchmark.rs
@@ -1,0 +1,71 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BatchSize};
+use lzss::{Lzss, VecWriter, SliceReader, ResultLzssErrorVoidExt};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("encompress heap example", |b| b.iter_batched(
+        || (SliceReader::new(EXAMPLE_DATA), VecWriter::with_capacity(EXAMPLE_DATA.len())),
+        |(r, w)| {
+            MyLzss::compress_heap(r, w).void_unwrap()
+        },
+        BatchSize::SmallInput,
+    ));
+    c.bench_function("encompress in-place example", |b| b.iter_batched(
+        || {
+            let mut v = vec![0; MyLzss::MIN_OFFSET + EXAMPLE_DATA.len() / 8];
+            v.extend(EXAMPLE_DATA);
+            v
+        },
+        |mut v| {
+            let (_, end) = MyLzss::compress_in_place(black_box(&mut v), MyLzss::MIN_OFFSET + EXAMPLE_DATA.len() / 8);
+            assert!(end.is_none());
+        },
+        BatchSize::SmallInput,
+    ));
+    c.bench_function("decompress heap example", |b| b.iter_batched(
+        || {
+            let compressed = MyLzss::compress_heap(
+                SliceReader::new(EXAMPLE_DATA),
+                VecWriter::with_capacity(EXAMPLE_DATA.len()),
+            ).void_unwrap();
+            (compressed, VecWriter::with_capacity(EXAMPLE_DATA.len()))
+        },
+        |(r, w)| {
+            MyLzss::decompress_heap(SliceReader::new(&r), w).void_unwrap()
+        },
+        BatchSize::SmallInput,
+    ));
+}
+
+const EI: usize = 10;
+const EJ: usize = 4;
+type MyLzss = Lzss<EI, EJ, 0x20, {1 << EI}, {2 << EI}>;
+
+const EXAMPLE_DATA: &[u8; 665] = br#"
+/* LZSS encoder-decoder (Haruhiko Okumura; public domain) */
+
+void decode(void)
+{
+    int i, j, k, r, c;
+
+    for (i = 0; i < N - F; i++) buffer[i] = ' ';
+    r = N - F;
+    while ((c = getbit(1)) != EOF) {
+        if (c) {
+            if ((c = getbit(8)) == EOF) break;
+            fputc(c, outfile);
+            buffer[r++] = c;  r &= (N - 1);
+        } else {
+            if ((i = getbit(EI)) == EOF) break;
+            if ((j = getbit(EJ)) == EOF) break;
+            for (k = 0; k <= j + 1; k++) {
+                c = buffer[(i + k) & (N - 1)];
+                fputc(c, outfile);
+                buffer[r++] = c;  r &= (N - 1);
+            }
+        }
+    }
+}
+"#;
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/lzss/src/dynamic/decompress.rs
+++ b/lzss/src/dynamic/decompress.rs
@@ -12,16 +12,19 @@ impl LzssDyn {
     writer: &mut W,
     buffer: &mut [u8],
   ) -> Result<(), LzssError<R::Error, W::Error>> {
+    let n = 1 << self.ei;
+    let index_mask = n - 1;
+    let buffer = &mut buffer[..n];
     let mut bit_reader = BitReader::new(reader);
 
-    let mut r = self.n() - self.f();
+    let mut r = n - self.f();
     loop {
       if let Some(c) = bit_reader.read_bits(1).map_err(LzssError::ReadError)? {
         if c != 0 {
           if let Some(b) = bit_reader.read_bits(8).map_err(LzssError::ReadError)? {
             writer.write(b as u8).map_err(LzssError::WriteError)?;
-            *unsafe { buffer.get_unchecked_mut(r) } = b as u8;
-            r = (r + 1) & (self.n() - 1);
+            buffer[r & index_mask] = b as u8;
+            r = r.wrapping_add(1);
           } else {
             return Ok(());
           }
@@ -32,10 +35,10 @@ impl LzssDyn {
           let i = (ij >> self.ej) as usize;
           let j = (ij & ((1 << self.ej) - 1)) as usize;
           for k in 0..=j + self.p() {
-            let b = *unsafe { buffer.get_unchecked((i + k) & (self.n() - 1)) };
+            let b = buffer[i.wrapping_add(k) & index_mask];
             writer.write(b).map_err(LzssError::WriteError)?;
-            *unsafe { buffer.get_unchecked_mut(r) } = b;
-            r = (r + 1) & (self.n() - 1);
+            buffer[r & index_mask] = b;
+            r = r.wrapping_add(1);
           }
         } else {
           return Ok(());

--- a/lzss/src/dynamic/mod.rs
+++ b/lzss/src/dynamic/mod.rs
@@ -110,7 +110,7 @@ impl LzssDyn {
     buffer: &mut [u8],
   ) -> Result<W::Output, LzssError<R::Error, W::Error>> {
     assert!(buffer.len() >= 2 * self.n());
-    unsafe { ::core::ptr::write_bytes(buffer.as_mut_ptr(), self.c, self.n() - self.f()) };
+    buffer[..self.n() - self.f()].fill(self.c);
     self.compress_internal(&mut reader, &mut writer, buffer)?;
     writer.finish().map_err(LzssError::WriteError)
   }
@@ -139,7 +139,7 @@ impl LzssDyn {
     buffer: &mut [u8],
   ) -> Result<W::Output, LzssError<R::Error, W::Error>> {
     assert!(buffer.len() >= self.n());
-    unsafe { ::core::ptr::write_bytes(buffer.as_mut_ptr(), self.c, self.n()) };
+    buffer[..self.n()].fill(self.c);
     self.decompress_internal(&mut reader, &mut writer, buffer)?;
     writer.finish().map_err(LzssError::WriteError)
   }

--- a/lzss/src/generic/compress.rs
+++ b/lzss/src/generic/compress.rs
@@ -26,7 +26,7 @@ impl<
       match reader.read().map_err(LzssError::ReadError)? {
         None => break,
         Some(data) => {
-          *unsafe { buffer.get_unchecked_mut(buffer_end) } = data;
+          buffer[buffer_end] = data;
           buffer_end += 1;
         }
       }
@@ -38,12 +38,12 @@ impl<
       let f1 = Self::F.min(buffer_end - r);
       let mut x = 0;
       let mut y = 1;
-      let c = *unsafe { buffer.get_unchecked(r) };
-      for i in (s..r).rev() {
-        if *unsafe { buffer.get_unchecked(i) } == c {
+      let c = buffer[r];
+      for (i, &ci) in (s..r).zip(&buffer[s..r]).rev() {
+        if ci == c {
           let mut j = 1;
           while j < f1 {
-            if *unsafe { buffer.get_unchecked(i + j) } != *unsafe { buffer.get_unchecked(r + j) } {
+            if buffer[i + j] != buffer[r + j] {
               break;
             }
             j += 1;
@@ -78,7 +78,7 @@ impl<
           match reader.read().map_err(LzssError::ReadError)? {
             None => break,
             Some(data) => {
-              *unsafe { buffer.get_unchecked_mut(buffer_end) } = data;
+              buffer[buffer_end] = data;
               buffer_end += 1;
             }
           }

--- a/lzss/src/generic/decompress.rs
+++ b/lzss/src/generic/decompress.rs
@@ -26,7 +26,7 @@ impl<
       if let Some(inp) = bit_reader.read_bits(9).map_err(LzssError::ReadError)? {
         if (inp & 0x100) != 0 {
           writer.write(inp as u8).map_err(LzssError::WriteError)?;
-          *unsafe { buffer.get_unchecked_mut(r) } = inp as u8;
+          buffer[r] = inp as u8;
           r = (r + 1) & (Self::N - 1);
         } else if let Some(inp2) = bit_reader
           .read_bits(EI + EJ - 8)
@@ -36,9 +36,9 @@ impl<
           let i = (inp >> EJ) as usize;
           let j = (inp & ((1 << EJ) - 1)) as usize;
           for k in 0..=j + Self::P {
-            let b = *unsafe { buffer.get_unchecked((i + k) & (Self::N - 1)) };
+            let b = buffer[(i + k) & (Self::N - 1)];
             writer.write(b).map_err(LzssError::WriteError)?;
-            *unsafe { buffer.get_unchecked_mut(r) } = b;
+            buffer[r] = b;
             r = (r + 1) & (Self::N - 1);
           }
         } else {

--- a/lzss/src/lib.rs
+++ b/lzss/src/lib.rs
@@ -3,6 +3,7 @@
 // Allow many single char names, this is done to copy the original code as close as possible.
 #![allow(clippy::many_single_char_names)]
 #![warn(missing_docs)]
+#![forbid(unsafe_code)]
 
 //! # Lempel–Ziv–Storer–Szymanski de-/compression
 //!


### PR DESCRIPTION
Hi! While evaluating this crate for use in a project, I noticed that it was using `unsafe` operations in a lot of places related to buffer indexing. Since this is a _very common_ source of security vulnerabilities in similar implementations (such as lz4), I was curious to see if I could remove the unsafe code without compromising performance.

In the end, I was able to remove all unsafe code without impacting performance or adding very much to the binary size.

This PR does the following:

1. Adds [`criterion`](https://bheisler.github.io/criterion.rs/book/criterion_rs.html) benchmarks for the main compression/decompression operations to make performance easier to quantify. (This also makes it convenient to apply profilers to detect hot spots; I mostly used Linux `perf`.)
2. Replaces `unsafe` code with safe equivalents. Many of the `unsafe` bits in the original were direct equivalents of safe library routines; most others were `get_unchecked` on slices. With this change, all internal accesses to buffers are now range-checked.
3. Add a `#![forbid(unsafe_code)]` at the top level to make it clear to readers that they should not expect to discover `unsafe`. (Not strictly necessary, but nice for auditing.)
4. Adds fuzz tests based on `honggfuzz` to see if those range-checks fail at any point given arbitrary, potentially malicious, input to compression/decompression. (They do not.)

I have mostly checked performance on x86-64 using Rust 1.65. I will be evaluating on ARMv7-M soon, but since Criterion doesn't support `no_std` that's a little more involved. Here is the performance impact of safe code on x86-64:

```
                            BEFORE  AFTER   CHANGE
generic compress heap       414.01  390.27   -5.73%
generic compress in-place   506.76  400.79  -20.91%
generic decompress            4.34    3.91   -9.91% ** see below
dynamic compress            386.04  381.60   -1.15%
dynamic decompress            3.87    4.16   +7.49%

- compressing/decompressing the EXAMPLE_DATA fixture
- all times in µs
```

Performance is generally unchanged except for compress-in-place, which is faster. (The apparent improvement in decompression speed is noise; the assembly code before and after is _identical._ I should test with a larger input to reduce measurement noise.) I have also profiled the benchmarks and inspected the disassembly to ensure that the hot spots that remain are not related to bounds checking etc. They are not.

The routines are similar in size or (in the case of `compress_in_place`) significantly smaller.

I can't currently explain the performance improvement to compress in-place; the original compiler output included a large and complex block of SSE instructions doing some sort of shuffle related to the `while out_len > 8` loop, and the new version just doesn't include that at all. The best I can come up with is that the use of checked indexing operations gives the compiler a lot more information about the possible range of index variables (since if they exceed the range of the array they're used with, the program terminates), which may have enabled it to be clever-er? Or perhaps less clever. In any case, the improvement appears stable across code changes, and puts performance closer to the non-in-place version, so I buy it.

The fuzz tests are arguably unrelated, so I'd be willing to extract them into a separate PR if you'd prefer. However, note that they do _depend_ on the use of safe code -- when code uses unchecked slice accesses, indexing off the end of a buffer won't reliably crash, and so won't be reliably detected by fuzz tests. You'd need to be using something like valgrind or miri in that case.